### PR TITLE
Improve layout of Slack+gCal buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,9 @@ for developers of all skill levels and disciplines.</h4>
         <a href="https://ubacm.slack.com/signup" target="_blank" rel="noopener">
           <img src="slack-button.png" alt="Join Slack">
         </a>
-        <a href="https://calendar.google.com/calendar/embed?src=ubacm.org%40gmail.com&ctz=America/New_York" target="_blank" rel="noopener"><img src="google-cal-button.png" style="margin-left:35px;"></a>
+        <a href="https://calendar.google.com/calendar/embed?src=ubacm.org%40gmail.com&ctz=America/New_York" target="_blank" rel="noopener">
+          <img src="google-cal-button.png" alt="Google Calendar">
+        </a>
       </div>
     </div>
   </div>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -151,6 +151,11 @@ body {
   margin-left: 0px;
 }
 
+.header .buttons a{
+  margin: 5px;
+  padding: 5px;
+}
+
 .row-header{
   width: 95%;
   height: 50px;


### PR DESCRIPTION
- The explicit margin on the gCal button forced things out of line
  on smaller screens when the button was forced to wrap to the
  next line so I replaced that with margin+padding on both buttons.
- Add alt text to gCal img